### PR TITLE
refactor(schema): Change all primary keys to autoincrement IDs

### DIFF
--- a/prisma/migrations/20241022185902_update_customer_code_length/migration.sql
+++ b/prisma/migrations/20241022185902_update_customer_code_length/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Customer" ALTER COLUMN "customer_code" SET DATA TYPE VARCHAR(100);

--- a/prisma/migrations/20241022190120_update_customer_id_type/migration.sql
+++ b/prisma/migrations/20241022190120_update_customer_id_type/migration.sql
@@ -1,0 +1,23 @@
+/*
+  Warnings:
+
+  - The primary key for the `Customer` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `customer_id` column on the `Customer` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - Changed the type of `customer_id` on the `Order` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Order" DROP CONSTRAINT "Order_customer_id_fkey";
+
+-- AlterTable
+ALTER TABLE "Customer" DROP CONSTRAINT "Customer_pkey",
+DROP COLUMN "customer_id",
+ADD COLUMN     "customer_id" SERIAL NOT NULL,
+ADD CONSTRAINT "Customer_pkey" PRIMARY KEY ("customer_id");
+
+-- AlterTable
+ALTER TABLE "Order" DROP COLUMN "customer_id",
+ADD COLUMN     "customer_id" INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Order" ADD CONSTRAINT "Order_customer_id_fkey" FOREIGN KEY ("customer_id") REFERENCES "Customer"("customer_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20241022191309_change_to_autoincrement_ids/migration.sql
+++ b/prisma/migrations/20241022191309_change_to_autoincrement_ids/migration.sql
@@ -1,0 +1,167 @@
+/*
+  Warnings:
+
+  - The `user_id` column on the `ChangeLog` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `last_modified_by` column on the `ChangeLog` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `last_modified_by` column on the `Customer` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `Enterprise` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `enterprise_id` column on the `Enterprise` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `last_modified_by` column on the `ItemType` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `Order` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `order_id` column on the `Order` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `last_modified_by` column on the `Order` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `last_modified_by` column on the `OrderItem` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `last_modified_by` column on the `QuickNote` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The primary key for the `User` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The `user_id` column on the `User` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - Changed the type of `enterprise_id` on the `ChangeLog` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `enterprise_id` on the `Customer` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `enterprise_id` on the `ItemType` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `enterprise_id` on the `Order` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `order_id` on the `OrderItem` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `enterprise_id` on the `OrderItem` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `order_id` on the `QuickNote` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `enterprise_id` on the `QuickNote` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ChangeLog" DROP CONSTRAINT "ChangeLog_enterprise_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ChangeLog" DROP CONSTRAINT "ChangeLog_last_modified_by_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Customer" DROP CONSTRAINT "Customer_enterprise_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Customer" DROP CONSTRAINT "Customer_last_modified_by_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ItemType" DROP CONSTRAINT "ItemType_enterprise_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "ItemType" DROP CONSTRAINT "ItemType_last_modified_by_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Order" DROP CONSTRAINT "Order_enterprise_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Order" DROP CONSTRAINT "Order_last_modified_by_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OrderItem" DROP CONSTRAINT "OrderItem_enterprise_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OrderItem" DROP CONSTRAINT "OrderItem_last_modified_by_fkey";
+
+-- DropForeignKey
+ALTER TABLE "OrderItem" DROP CONSTRAINT "OrderItem_order_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "QuickNote" DROP CONSTRAINT "QuickNote_enterprise_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "QuickNote" DROP CONSTRAINT "QuickNote_last_modified_by_fkey";
+
+-- DropForeignKey
+ALTER TABLE "QuickNote" DROP CONSTRAINT "QuickNote_order_id_fkey";
+
+-- AlterTable
+ALTER TABLE "ChangeLog" DROP COLUMN "user_id",
+ADD COLUMN     "user_id" INTEGER,
+DROP COLUMN "enterprise_id",
+ADD COLUMN     "enterprise_id" INTEGER NOT NULL,
+DROP COLUMN "last_modified_by",
+ADD COLUMN     "last_modified_by" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Customer" DROP COLUMN "enterprise_id",
+ADD COLUMN     "enterprise_id" INTEGER NOT NULL,
+DROP COLUMN "last_modified_by",
+ADD COLUMN     "last_modified_by" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Enterprise" DROP CONSTRAINT "Enterprise_pkey",
+DROP COLUMN "enterprise_id",
+ADD COLUMN     "enterprise_id" SERIAL NOT NULL,
+ADD CONSTRAINT "Enterprise_pkey" PRIMARY KEY ("enterprise_id");
+
+-- AlterTable
+ALTER TABLE "ItemType" DROP COLUMN "enterprise_id",
+ADD COLUMN     "enterprise_id" INTEGER NOT NULL,
+DROP COLUMN "last_modified_by",
+ADD COLUMN     "last_modified_by" INTEGER;
+
+-- AlterTable
+ALTER TABLE "Order" DROP CONSTRAINT "Order_pkey",
+DROP COLUMN "order_id",
+ADD COLUMN     "order_id" SERIAL NOT NULL,
+DROP COLUMN "enterprise_id",
+ADD COLUMN     "enterprise_id" INTEGER NOT NULL,
+DROP COLUMN "last_modified_by",
+ADD COLUMN     "last_modified_by" INTEGER,
+ADD CONSTRAINT "Order_pkey" PRIMARY KEY ("order_id");
+
+-- AlterTable
+ALTER TABLE "OrderItem" DROP COLUMN "order_id",
+ADD COLUMN     "order_id" INTEGER NOT NULL,
+DROP COLUMN "enterprise_id",
+ADD COLUMN     "enterprise_id" INTEGER NOT NULL,
+DROP COLUMN "last_modified_by",
+ADD COLUMN     "last_modified_by" INTEGER;
+
+-- AlterTable
+ALTER TABLE "QuickNote" DROP COLUMN "order_id",
+ADD COLUMN     "order_id" INTEGER NOT NULL,
+DROP COLUMN "enterprise_id",
+ADD COLUMN     "enterprise_id" INTEGER NOT NULL,
+DROP COLUMN "last_modified_by",
+ADD COLUMN     "last_modified_by" INTEGER;
+
+-- AlterTable
+ALTER TABLE "User" DROP CONSTRAINT "User_pkey",
+DROP COLUMN "user_id",
+ADD COLUMN     "user_id" SERIAL NOT NULL,
+ADD CONSTRAINT "User_pkey" PRIMARY KEY ("user_id");
+
+-- AddForeignKey
+ALTER TABLE "Customer" ADD CONSTRAINT "Customer_enterprise_id_fkey" FOREIGN KEY ("enterprise_id") REFERENCES "Enterprise"("enterprise_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Customer" ADD CONSTRAINT "Customer_last_modified_by_fkey" FOREIGN KEY ("last_modified_by") REFERENCES "User"("user_id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Order" ADD CONSTRAINT "Order_enterprise_id_fkey" FOREIGN KEY ("enterprise_id") REFERENCES "Enterprise"("enterprise_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Order" ADD CONSTRAINT "Order_last_modified_by_fkey" FOREIGN KEY ("last_modified_by") REFERENCES "User"("user_id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_order_id_fkey" FOREIGN KEY ("order_id") REFERENCES "Order"("order_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_enterprise_id_fkey" FOREIGN KEY ("enterprise_id") REFERENCES "Enterprise"("enterprise_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_last_modified_by_fkey" FOREIGN KEY ("last_modified_by") REFERENCES "User"("user_id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ItemType" ADD CONSTRAINT "ItemType_enterprise_id_fkey" FOREIGN KEY ("enterprise_id") REFERENCES "Enterprise"("enterprise_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ItemType" ADD CONSTRAINT "ItemType_last_modified_by_fkey" FOREIGN KEY ("last_modified_by") REFERENCES "User"("user_id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "QuickNote" ADD CONSTRAINT "QuickNote_order_id_fkey" FOREIGN KEY ("order_id") REFERENCES "Order"("order_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "QuickNote" ADD CONSTRAINT "QuickNote_enterprise_id_fkey" FOREIGN KEY ("enterprise_id") REFERENCES "Enterprise"("enterprise_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "QuickNote" ADD CONSTRAINT "QuickNote_last_modified_by_fkey" FOREIGN KEY ("last_modified_by") REFERENCES "User"("user_id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChangeLog" ADD CONSTRAINT "ChangeLog_enterprise_id_fkey" FOREIGN KEY ("enterprise_id") REFERENCES "Enterprise"("enterprise_id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChangeLog" ADD CONSTRAINT "ChangeLog_last_modified_by_fkey" FOREIGN KEY ("last_modified_by") REFERENCES "User"("user_id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20241022191543_change_entity_id_to_int/migration.sql
+++ b/prisma/migrations/20241022191543_change_entity_id_to_int/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Changed the type of `entity_id` on the `ChangeLog` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+
+*/
+-- AlterTable
+ALTER TABLE "ChangeLog" DROP COLUMN "entity_id",
+ADD COLUMN     "entity_id" INTEGER NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,7 @@ generator client {
 
 /// The `User` model represents the system users who modify records.
 model User {
-  user_id    String @id @default(uuid()) @db.VarChar(36) /// Unique identifier for each user.
+  user_id    Int    @id @default(autoincrement()) /// Unique identifier for each user.
   user_name  String @db.VarChar(100) /// The name of the user.
   user_email String @unique @db.VarChar(100) /// The email of the user.
 
@@ -24,7 +24,7 @@ model User {
 
 /// The `Enterprise` model represents an individual enterprise (or tenant) in the system.
 model Enterprise {
-  enterprise_id   String @id @default(uuid()) @db.VarChar(36) /// Unique identifier for each enterprise.
+  enterprise_id   Int    @id @default(autoincrement()) /// Unique identifier for each enterprise.
   enterprise_name String @db.VarChar(100) /// The name of the enterprise.
 
   // Relation fields
@@ -38,9 +38,9 @@ model Enterprise {
 
 /// The `Customer` model represents individual customers linked to a specific enterprise.
 model Customer {
-  customer_id      String  @id @default(uuid()) @db.VarChar(10) /// Unique identifier for the customer.
+  customer_id      Int     @id @default(autoincrement()) /// Unique identifier for the customer.
   customer_name    String  @db.VarChar(100) /// The customer's full name.
-  customer_code    String  @unique @db.VarChar(10) /// Unique customer code used in the system.
+  customer_code    String  @unique @db.VarChar(100) /// Unique customer code used in the system.
   customer_email   String? @db.VarChar(100) /// The customer's email (nullable).
   customer_phone   String? @db.VarChar(15) /// The customer's phone number (nullable).
   customer_address String? @db.VarChar(255) /// The customer's full address (nullable).
@@ -50,8 +50,8 @@ model Customer {
   bank_account_no   String? @db.VarChar(30) /// The customer's bank account number (nullable).
   bank_account_type String? @db.VarChar(50) /// The type of bank account (e.g., Savings, Checking) (nullable).
 
-  enterprise_id    String  @db.VarChar(36) /// Foreign key to the enterprise that owns this customer.
-  last_modified_by String? @db.VarChar(36) /// Foreign key to the user who last modified this record.
+  enterprise_id    Int /// Foreign key to the enterprise that owns this customer.
+  last_modified_by Int? /// Foreign key to the user who last modified this record.
 
   // Relations
   enterprise     Enterprise @relation(fields: [enterprise_id], references: [enterprise_id]) /// Each customer belongs to one enterprise.
@@ -61,15 +61,15 @@ model Customer {
 
 /// The `Order` model represents individual orders placed by customers within an enterprise.
 model Order {
-  order_id         String   @id @default(uuid()) @db.VarChar(10) /// Unique identifier for each order.
-  customer_id      String   @db.VarChar(10) /// Foreign key relating to the customer who placed the order.
+  order_id         Int      @id @default(autoincrement()) /// Unique identifier for each order.
+  customer_id      Int /// Foreign key relating to the customer who placed the order.
   total_price      Decimal  @db.Decimal(10, 2) /// The total price of the order.
   order_date       DateTime /// The date and time the order was placed.
   order_status     String   @default("Pending") @db.VarChar(20) /// The current status of the order (Pending, Shipped, Delivered).
   payment_status   String   @default("Unpaid") @db.VarChar(20) /// The payment status of the order (Paid, Unpaid).
   pay_slip_image   String?  @db.VarChar(255) /// The link or path to the payment slip image (nullable).
-  enterprise_id    String   @db.VarChar(36) /// Foreign key to the enterprise that owns this order.
-  last_modified_by String?  @db.VarChar(36) /// Foreign key to the user who last modified this record.
+  enterprise_id    Int /// Foreign key to the enterprise that owns this order.
+  last_modified_by Int? /// Foreign key to the user who last modified this record.
 
   // Relations
   customer       Customer    @relation(fields: [customer_id], references: [customer_id]) /// Each order belongs to one customer.
@@ -82,13 +82,13 @@ model Order {
 /// The `OrderItem` model represents individual items within an order, linked to an enterprise.
 model OrderItem {
   order_item_id    Int     @id @default(autoincrement()) /// Unique identifier for each order item.
-  order_id         String  @db.VarChar(10) /// Foreign key relating to the order this item belongs to.
+  order_id         Int /// Foreign key relating to the order this item belongs to.
   number_value     String  @db.VarChar(10) /// The lottery number selected by the customer.
   item_type_id     Int /// Foreign key relating to the type of lottery item.
   quantity         Int     @default(1) /// The quantity of this item ordered.
   price            Decimal @db.Decimal(10, 2) /// The price for this item.
-  enterprise_id    String  @db.VarChar(36) /// Foreign key to the enterprise that owns this order item.
-  last_modified_by String? @db.VarChar(36) /// Foreign key to the user who last modified this record.
+  enterprise_id    Int /// Foreign key to the enterprise that owns this order item.
+  last_modified_by Int? /// Foreign key to the user who last modified this record.
 
   // Relations
   order          Order      @relation(fields: [order_id], references: [order_id]) /// Many order items belong to one order.
@@ -99,10 +99,10 @@ model OrderItem {
 
 /// The `ItemType` model represents different types of lottery items, specific to each enterprise.
 model ItemType {
-  item_type_id     Int     @id @default(autoincrement()) /// Unique identifier for the item type.
-  type_name        String  @unique @db.VarChar(50) /// The name of the item type (e.g., 2 ตัวบน, 2 ตัวล่าง).
-  enterprise_id    String  @db.VarChar(36) /// Foreign key to the enterprise that owns this item type.
-  last_modified_by String? @db.VarChar(36) /// Foreign key to the user who last modified this record.
+  item_type_id     Int    @id @default(autoincrement()) /// Unique identifier for the item type.
+  type_name        String @unique @db.VarChar(50) /// The name of the item type (e.g., 2 ตัวบน, 2 ตัวล่าง).
+  enterprise_id    Int /// Foreign key to the enterprise that owns this item type.
+  last_modified_by Int? /// Foreign key to the user who last modified this record.
 
   // Relations
   order_items    OrderItem[] /// One item type can belong to multiple order items.
@@ -114,11 +114,11 @@ model ItemType {
 model QuickNote {
   note_id          Int      @id @default(autoincrement()) /// Unique identifier for the quick note.
   note_description String   @db.Text /// The description of the quick note.
-  order_id         String   @db.VarChar(10) /// Foreign key relating to the order this note belongs to.
+  order_id         Int /// Foreign key relating to the order this note belongs to.
   created_at       DateTime @default(now()) /// Timestamp for when the note was created.
   updated_at       DateTime @updatedAt /// Timestamp for when the note was last updated.
-  enterprise_id    String   @db.VarChar(36) /// Foreign key to the enterprise that owns this quick note.
-  last_modified_by String?  @db.VarChar(36) /// Foreign key to the user who last modified this record.
+  enterprise_id    Int /// Foreign key to the enterprise that owns this quick note.
+  last_modified_by Int? /// Foreign key to the user who last modified this record.
 
   // Relations
   order          Order      @relation(fields: [order_id], references: [order_id]) /// Many quick notes belong to one order.
@@ -131,13 +131,13 @@ model ChangeLog {
   log_id           Int      @id @default(autoincrement()) /// Unique identifier for each log entry.
   entity_name      String   @db.VarChar(50) /// The name of the entity being changed (e.g., Customer, Order).
   action           String   @db.VarChar(20) /// The type of action performed (create, update, delete).
-  entity_id        String   @db.VarChar(50) /// The ID of the entity that was changed.
-  user_id          String?  @db.VarChar(50) /// The ID of the user who performed the action (optional).
+  entity_id        Int /// The ID of the entity that was changed.
+  user_id          Int? /// The ID of the user who performed the action (optional).
   before_data      Json? /// JSON object containing the data before the change (nullable).
   after_data       Json? /// JSON object containing the data after the change (nullable).
   change_time      DateTime @default(now()) /// Timestamp of when the change was made.
-  enterprise_id    String   @db.VarChar(36) /// The enterprise to which this change log belongs.
-  last_modified_by String?  @db.VarChar(36) /// Foreign key to the user who last modified this record.
+  enterprise_id    Int /// The enterprise to which this change log belongs.
+  last_modified_by Int? /// Foreign key to the user who last modified this record.
 
   // Relations
   enterprise     Enterprise @relation(fields: [enterprise_id], references: [enterprise_id]) /// Each change log belongs to one enterprise.

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -6,14 +6,12 @@ async function main() {
   // Seed data for Enterprise
   const enterprise1 = await prisma.enterprise.create({
     data: {
-      enterprise_id: 'enterprise-id-1',
       enterprise_name: 'Smart Lotto Thailand',
     },
   });
 
   const enterprise2 = await prisma.enterprise.create({
     data: {
-      enterprise_id: 'enterprise-id-2',
       enterprise_name: 'Smart Lotto International',
     },
   });
@@ -21,7 +19,6 @@ async function main() {
   // Seed data for User
   const user1 = await prisma.user.create({
     data: {
-      user_id: 'user-id-1',
       user_name: 'Admin User',
       user_email: 'admin@example.com',
     },
@@ -29,7 +26,6 @@ async function main() {
 
   const user2 = await prisma.user.create({
     data: {
-      user_id: 'user-id-2',
       user_name: 'Manager User',
       user_email: 'manager@example.com',
     },

--- a/src/customer/customer.controller.spec.ts
+++ b/src/customer/customer.controller.spec.ts
@@ -34,7 +34,7 @@ describe('CustomerController', () => {
   describe('getCustomerById', () => {
     it('should return a customer by ID', async () => {
       const mockCustomer = {
-        customer_id: '1',
+        customer_id: 1,
         customer_name: 'John Doe',
         customer_code: 'JD123',
         customer_email: 'john@example.com',
@@ -43,30 +43,30 @@ describe('CustomerController', () => {
         bank_name: 'Bank ABC',
         bank_account_no: '1234567890',
         bank_account_type: 'Savings',
-        enterprise_id: 'enterprise123',
-        last_modified_by: 'admin',
+        enterprise_id: 1,
+        last_modified_by: 1,
       };
       jest.spyOn(service, 'findCustomerById').mockResolvedValue(mockCustomer);
 
-      const result = await controller.getCustomerById('1');
+      const result = await controller.getCustomerById(1);
       expect(result).toEqual(mockCustomer);
-      expect(service.findCustomerById).toHaveBeenCalledWith('1');
+      expect(service.findCustomerById).toHaveBeenCalledWith(1);
     });
 
     it('should throw a NotFoundException if customer is not found', async () => {
       jest.spyOn(service, 'findCustomerById').mockResolvedValue(null);
 
-      await expect(controller.getCustomerById('1')).rejects.toThrow(
+      await expect(controller.getCustomerById(1)).rejects.toThrow(
         NotFoundException,
       );
-      expect(service.findCustomerById).toHaveBeenCalledWith('1');
+      expect(service.findCustomerById).toHaveBeenCalledWith(1);
     });
   });
 
   describe('createCustomer', () => {
     it('should create a new customer', async () => {
       const mockCustomer = {
-        customer_id: '1',
+        customer_id: 1,
         customer_name: 'John Doe',
         customer_code: 'JD123',
         customer_email: 'john@example.com',
@@ -75,8 +75,8 @@ describe('CustomerController', () => {
         bank_name: 'Bank ABC',
         bank_account_no: '1234567890',
         bank_account_type: 'Savings',
-        enterprise_id: 'enterprise123',
-        last_modified_by: 'admin',
+        enterprise_id: 1,
+        last_modified_by: 1,
       };
       jest.spyOn(service, 'createCustomer').mockResolvedValue(mockCustomer);
 
@@ -87,15 +87,15 @@ describe('CustomerController', () => {
       };
       const result = await controller.createCustomer(
         customerData,
-        'user123',
-        'enterprise123',
+        1,
+        1,
       );
 
       expect(result).toEqual(mockCustomer);
       expect(service.createCustomer).toHaveBeenCalledWith(
         customerData,
-        'user123',
-        'enterprise123',
+        1,
+        1,
       );
     });
   });
@@ -103,7 +103,7 @@ describe('CustomerController', () => {
   describe('updateCustomer', () => {
     it('should update a customer', async () => {
       const mockUpdatedCustomer = {
-        customer_id: '1',
+        customer_id: 1,
         customer_name: 'John Smith',
         customer_code: 'JS123',
         customer_email: 'johnsmith@example.com',
@@ -112,8 +112,8 @@ describe('CustomerController', () => {
         bank_name: 'Bank XYZ',
         bank_account_no: '9876543210',
         bank_account_type: 'Checking',
-        enterprise_id: 'enterprise456',
-        last_modified_by: 'admin',
+        enterprise_id: 2,
+        last_modified_by: 1,
       };
       jest
         .spyOn(service, 'updateCustomer')
@@ -125,18 +125,18 @@ describe('CustomerController', () => {
         email: 'johnsmith@example.com',
       };
       const result = await controller.updateCustomer(
-        '1',
+        1,
         updateData,
-        'user123',
-        'enterprise123',
+        1,
+        1,
       );
 
       expect(result).toEqual(mockUpdatedCustomer);
       expect(service.updateCustomer).toHaveBeenCalledWith(
-        '1',
+        1,
         updateData,
-        'user123',
-        'enterprise123',
+        1,
+        1,
       );
     });
   });
@@ -146,16 +146,16 @@ describe('CustomerController', () => {
       jest.spyOn(service, 'deleteCustomer').mockResolvedValue(true);
 
       const result = await controller.deleteCustomer(
-        '1',
-        'user123',
-        'enterprise123',
+        1,
+        1,
+        1,
       );
 
       expect(result).toEqual({ message: 'Customer deleted successfully' });
       expect(service.deleteCustomer).toHaveBeenCalledWith(
-        '1',
-        'user123',
-        'enterprise123',
+        1,
+        1,
+        1,
       );
     });
   });

--- a/src/customer/customer.controller.ts
+++ b/src/customer/customer.controller.ts
@@ -16,8 +16,8 @@ export class CustomerController {
 
   // Fetch a customer by ID
   @Get(':id')
-  async getCustomerById(@Param('id') id: string) {
-    const customer = await this.customerService.findCustomerById(id);
+  async getCustomerById(@Param('id') id: number) {
+    const customer = await this.customerService.findCustomerById(Number(id));
     if (!customer) {
       throw new NotFoundException(`Customer with ID ${id} not found`);
     }
@@ -27,30 +27,30 @@ export class CustomerController {
   // Create a new customer
   @Post()
   async createCustomer(
-    @Body() customerData: { name: string; code: string, email: string },
-    @Body('userId') userId: string,
-    @Body('enterpriseId') enterpriseId: string,
+    @Body() customerData: { name: string; code: string; email: string },
+    @Body('userId') userId: number,
+    @Body('enterpriseId') enterpriseId: number,
   ) {
     return this.customerService.createCustomer(
       customerData,
-      userId,
-      enterpriseId,
+      Number(userId),
+      Number(enterpriseId),
     );
   }
 
   // Update an existing customer
   @Put(':id')
   async updateCustomer(
-    @Param('id') id: string,
+    @Param('id') id: number,
     @Body() customerData: { name?: string; email?: string },
-    @Body('userId') userId: string,
-    @Body('enterpriseId') enterpriseId: string,
+    @Body('userId') userId: number,
+    @Body('enterpriseId') enterpriseId: number,
   ) {
     const updatedCustomer = await this.customerService.updateCustomer(
-      id,
+      Number(id),
       customerData,
-      userId,
-      enterpriseId,
+      Number(userId),
+      Number(enterpriseId),
     );
     if (!updatedCustomer) {
       throw new NotFoundException(`Customer with ID ${id} not found`);
@@ -61,14 +61,14 @@ export class CustomerController {
   // Delete a customer by ID
   @Delete(':id')
   async deleteCustomer(
-    @Param('id') id: string,
-    @Body('userId') userId: string,
-    @Body('enterpriseId') enterpriseId: string,
+    @Param('id') id: number,
+    @Body('userId') userId: number,
+    @Body('enterpriseId') enterpriseId: number,
   ) {
     const success = await this.customerService.deleteCustomer(
-      id,
-      userId,
-      enterpriseId,
+      Number(id),
+      Number(userId),
+      Number(enterpriseId),
     );
     if (!success) {
       throw new NotFoundException(`Customer with ID ${id} not found`);

--- a/src/customer/customer.service.spec.ts
+++ b/src/customer/customer.service.spec.ts
@@ -38,7 +38,7 @@ describe('CustomerService', () => {
   describe('findCustomerById', () => {
     it('should return a customer if found', async () => {
       const mockCustomer = {
-        customer_id: '1',
+        customer_id: 1,
         customer_name: 'John Doe',
         customer_code: 'JD123',
         customer_email: 'john@example.com',
@@ -47,25 +47,25 @@ describe('CustomerService', () => {
         bank_name: 'Bank ABC',
         bank_account_no: '1234567890',
         bank_account_type: 'Savings',
-        enterprise_id: 'enterprise123',
-        last_modified_by: 'admin',
+        enterprise_id: 1,
+        last_modified_by: 1,
       };
       jest.spyOn(prisma.customer, 'findUnique').mockResolvedValue(mockCustomer);
 
-      const result = await service.findCustomerById('1');
+      const result = await service.findCustomerById(1);
       expect(result).toEqual(mockCustomer);
       expect(prisma.customer.findUnique).toHaveBeenCalledWith({
-        where: { customer_id: '1' },
+        where: { customer_id: 1 },
       });
     });
 
     it('should return null if customer is not found', async () => {
       jest.spyOn(prisma.customer, 'findUnique').mockResolvedValue(null);
 
-      const result = await service.findCustomerById('1');
+      const result = await service.findCustomerById(1);
       expect(result).toBeNull();
       expect(prisma.customer.findUnique).toHaveBeenCalledWith({
-        where: { customer_id: '1' },
+        where: { customer_id: 1 },
       });
     });
   });
@@ -73,7 +73,7 @@ describe('CustomerService', () => {
   describe('createCustomer', () => {
     it('should create and return a new customer', async () => {
       const mockCustomer = {
-        customer_id: '1',
+        customer_id: 1,
         customer_name: 'John Doe',
         customer_code: 'JD123',
         customer_email: 'john@example.com',
@@ -82,8 +82,8 @@ describe('CustomerService', () => {
         bank_name: 'Bank ABC',
         bank_account_no: '1234567890',
         bank_account_type: 'Savings',
-        enterprise_id: 'enterprise123',
-        last_modified_by: 'admin',
+        enterprise_id: 1,
+        last_modified_by: 1,
       };
       jest.spyOn(prisma.customer, 'create').mockResolvedValue(mockCustomer);
       jest.spyOn(prisma.changeLog, 'create').mockResolvedValue({
@@ -91,18 +91,18 @@ describe('CustomerService', () => {
         after_data: mockCustomer,
         before_data: null,
         change_time: new Date(),
-        enterprise_id: 'enterprise123',
-        entity_id: '1',
+        enterprise_id: 1,
+        entity_id: 1,
         entity_name: 'Customer',
-        user_id: 'user123',
+        user_id: 1,
         log_id: 1,
-        last_modified_by: 'admin',
+        last_modified_by: 1,
       }); // Mock the log creation
 
       const result = await service.createCustomer(
         { name: 'John Doe', code: 'JD123', email: 'john@example.com' },
-        'user123',
-        'enterprise123',
+        1,
+        1,
       );
       expect(result).toEqual(mockCustomer);
       expect(prisma.customer.create).toHaveBeenCalledWith({
@@ -110,7 +110,7 @@ describe('CustomerService', () => {
           customer_name: 'John Doe',
           customer_code: 'JD123', // Fixed the customer_code
           customer_email: 'john@example.com',
-          enterprise_id: 'enterprise123',
+          enterprise_id: 1,
         },
       });
     });
@@ -119,7 +119,7 @@ describe('CustomerService', () => {
   describe('updateCustomer', () => {
     it('should update and return an existing customer', async () => {
       const mockUpdatedCustomer = {
-        customer_id: '1',
+        customer_id: 1,
         customer_name: 'John Smith',
         customer_code: 'John Smith',
         customer_email: 'john@example.com',
@@ -128,8 +128,8 @@ describe('CustomerService', () => {
         bank_name: 'Bank ABC',
         bank_account_no: '1234567890',
         bank_account_type: 'Savings',
-        enterprise_id: 'enterprise123',
-        last_modified_by: 'admin',
+        enterprise_id: 1,
+        last_modified_by: 1,
       };
       jest
         .spyOn(prisma.customer, 'update')
@@ -140,23 +140,23 @@ describe('CustomerService', () => {
         after_data: mockUpdatedCustomer,
         before_data: null,
         change_time: new Date(),
-        enterprise_id: 'enterprise123',
-        entity_id: '1',
+        enterprise_id: 1,
+        entity_id: 1,
         entity_name: 'Customer',
-        user_id: 'user123',
+        user_id: 1,
         log_id: 1,
-        last_modified_by: 'admin',
+        last_modified_by: 1,
       }); // Mock the log creation
 
       const result = await service.updateCustomer(
-        '1',
+        1,
         { name: 'John Smith', email: 'john@example.com' },
-        'user123',
-        'enterprise123',
+        1,
+        1,
       );
       expect(result).toEqual(mockUpdatedCustomer);
       expect(prisma.customer.update).toHaveBeenCalledWith({
-        where: { customer_id: '1' },
+        where: { customer_id: 1 },
         data: {
           customer_name: 'John Smith',
           customer_email: 'john@example.com',
@@ -167,7 +167,7 @@ describe('CustomerService', () => {
   describe('deleteCustomer', () => {
     it('should delete a customer and return true', async () => {
       const mockCustomer = {
-        customer_id: '1',
+        customer_id: 1,
         customer_name: 'John Doe',
         customer_code: 'JD123',
         customer_email: 'john@example.com',
@@ -176,8 +176,8 @@ describe('CustomerService', () => {
         bank_name: 'Bank ABC',
         bank_account_no: '1234567890',
         bank_account_type: 'Savings',
-        enterprise_id: 'enterprise123',
-        last_modified_by: 'admin',
+        enterprise_id: 1,
+        last_modified_by: 1,
       };
 
       jest.spyOn(prisma.customer, 'delete').mockResolvedValue(mockCustomer);
@@ -186,23 +186,23 @@ describe('CustomerService', () => {
         after_data: mockCustomer,
         before_data: null,
         change_time: new Date(),
-        enterprise_id: 'enterprise123',
-        entity_id: '1',
+        enterprise_id: 1,
+        entity_id: 1,
         entity_name: 'Customer',
-        user_id: 'user123',
+        user_id: 1,
         log_id: 1,
-        last_modified_by: 'admin',
+        last_modified_by: 1,
       }); // Mock the log creation
 
       const result = await service.deleteCustomer(
-        '1',
-        'user123',
-        'enterprise123',
+        1,
+        1,
+        1,
       );
 
       expect(result).toEqual(true);
       expect(prisma.customer.delete).toHaveBeenCalledWith({
-        where: { customer_id: '1' },
+        where: { customer_id: 1 },
       });
     });
   });

--- a/src/customer/customer.service.ts
+++ b/src/customer/customer.service.ts
@@ -10,7 +10,7 @@ export class CustomerService {
    * @param customerId - The unique ID of the customer.
    * @returns The customer data if found, or null if not found.
    */
-  async findCustomerById(customerId: string) {
+  async findCustomerById(customerId: number) {
     return this.prisma.customer.findUnique({
       where: { customer_id: customerId }, // Assumes the ID field is 'customer_id' in the database
     });
@@ -18,8 +18,8 @@ export class CustomerService {
 
   async createCustomer(
     data: { name: string; code: string; email: string },
-    userId: string,
-    enterpriseId: string,
+    userId: number,
+    enterpriseId: number,
   ) {
     const customer = await this.prisma.customer.create({
       data: {
@@ -46,10 +46,10 @@ export class CustomerService {
   }
 
   async updateCustomer(
-    customerId: string,
+    customerId: number,
     data: { name?: string; email?: string },
-    userId: string,
-    enterpriseId: string,
+    userId: number,
+    enterpriseId: number,
   ) {
     // Fetch the current data before update
     const beforeData = await this.prisma.customer.findUnique({
@@ -81,9 +81,9 @@ export class CustomerService {
   }
 
   async deleteCustomer(
-    customerId: string,
-    userId: string,
-    enterpriseId: string,
+    customerId: number,
+    userId: number,
+    enterpriseId: number,
   ) {
     // Fetch the current data before delete
     const customer = await this.prisma.customer.findUnique({


### PR DESCRIPTION
- Updated primary keys in all models (User, Enterprise, Customer, Order, etc.) to use Int with autoincrement().
- Adjusted foreign key relationships to reflect the new Int-based primary keys.
- Migrated the schema to ensure compatibility with autoincrement ID fields.
