### PR TITLE
feat: add optional enterprise_id field to User model

### DIFF
--- a/prisma/migrations/20241024163039_change_order_date_default_now/migration.sql
+++ b/prisma/migrations/20241024163039_change_order_date_default_now/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Order" ALTER COLUMN "order_date" SET DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/migrations/20241024174042_add_enterprise_id_to_user_model/migration.sql
+++ b/prisma/migrations/20241024174042_add_enterprise_id_to_user_model/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "enterprise_id" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "User" ADD CONSTRAINT "User_enterprise_id_fkey" FOREIGN KEY ("enterprise_id") REFERENCES "Enterprise"("enterprise_id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,10 @@ model User {
   password      String  @db.VarChar(255) /// The password hash for the user.
   refresh_token String? @db.VarChar(255) /// Optional refresh token for session management.
 
+  // Optional Enterprise relation
+  enterprise_id Int? /// Foreign key to the enterprise this user belongs to (nullable)
+  enterprise    Enterprise? @relation(fields: [enterprise_id], references: [enterprise_id]) /// Each user can optionally belong to one enterprise.
+
   // Relations
   customers  Customer[]  @relation("CustomerLastModifiedBy")
   orders     Order[]     @relation("OrderLastModifiedBy")
@@ -37,9 +41,10 @@ model Enterprise {
   customers  Customer[] /// One enterprise can have many customers.
   orders     Order[] /// One enterprise can have many orders.
   item_types ItemType[] /// One enterprise can have many item types.
-  OrderItem  OrderItem[]
-  QuickNote  QuickNote[]
-  ChangeLog  ChangeLog[]
+  orderItem  OrderItem[]
+  quickNote  QuickNote[]
+  changeLog  ChangeLog[]
+  user       User[]
 }
 
 /// The `Customer` model represents individual customers linked to a specific enterprise.
@@ -70,7 +75,7 @@ model Order {
   order_id         Int      @id @default(autoincrement()) /// Unique identifier for each order.
   customer_id      Int /// Foreign key relating to the customer who placed the order.
   total_price      Decimal  @db.Decimal(10, 2) /// The total price of the order.
-  order_date       DateTime /// The date and time the order was placed.
+  order_date       DateTime @default(now()) /// The date and time the order was placed.
   order_status     String   @default("Pending") @db.VarChar(20) /// The current status of the order (Pending, Shipped, Delivered).
   payment_status   String   @default("Unpaid") @db.VarChar(20) /// The payment status of the order (Paid, Unpaid).
   pay_slip_image   String?  @db.VarChar(255) /// The link or path to the payment slip image (nullable).

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,10 +7,11 @@ import { AuthModule } from './auth/auth.module';
 import { UserModule } from './user/user.module';
 import { EnterpriseModule } from './enterprise/enterprise.module';
 import { ItemTypeModule } from './item-type/item-type.module';
+import { OrderModule } from './order/order.module';
 
 
 @Module({
-  imports: [PrismaModule, CustomerModule, AuthModule, UserModule, EnterpriseModule, ItemTypeModule],
+  imports: [PrismaModule, CustomerModule, AuthModule, UserModule, EnterpriseModule, ItemTypeModule, OrderModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -27,7 +27,7 @@ export class AuthService {
 
   // Generate a JWT token
   async generateAccessToken(user: any): Promise<string> {
-    const payload = { userId: user.user_id, email: user.user_email };
+    const payload = { user_id: user.user_id, enterprise_id: user.enterprise_id, email: user.user_email };
     return jwt.sign(payload, process.env.JWT_SECRET, { expiresIn: '1h' });
   }
 

--- a/src/auth/decorators/get-user.decorator.ts
+++ b/src/auth/decorators/get-user.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const GetUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/src/auth/jwt-auth.guard.ts
+++ b/src/auth/jwt-auth.guard.ts
@@ -1,5 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  canActivate(context: ExecutionContext) {
+    return super.canActivate(context);
+  }
+
+  handleRequest(err, user, info) {
+    if (err || !user) {
+      throw new UnauthorizedException('Unauthorized');
+    } else {
+      return user;
+    }
+  }
+}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -4,7 +4,7 @@ import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()
-export class JwtStrategy extends PassportStrategy(Strategy) {
+export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
   constructor(private configService: ConfigService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -14,6 +14,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    return { userId: payload.sub, email: payload.email };
+    return { ...payload, user_id: payload.user_id, enterprise_id: payload.enterprise_id, email: payload.email };
   }
 }

--- a/src/order/dto/order.dto.ts
+++ b/src/order/dto/order.dto.ts
@@ -1,0 +1,61 @@
+import { Decimal } from '@prisma/client/runtime/library';
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsNumber,
+  IsString,
+  IsDecimal,
+  IsInt,
+} from 'class-validator';
+
+export class CreateOrderDto {
+  @IsNotEmpty()
+  @IsNumber()
+  customer_id: number; // Foreign key for the customer placing the order
+
+  @IsNotEmpty()
+  @IsDecimal()
+  total_price: Decimal; // Total price for the order
+
+  @IsNotEmpty()
+  @IsString()
+  order_status: string; // Order status (e.g., Pending, Shipped, Delivered)
+
+  @IsNotEmpty()
+  @IsString()
+  payment_status: string; // Payment status (e.g., Paid, Unpaid)
+
+  @IsOptional()
+  @IsString()
+  pay_slip_image?: string; // Optional pay slip image link
+
+  @IsNotEmpty()
+  @IsNumber()
+  enterprise_id: number; // Foreign key for the enterprise associated with the order
+}
+
+export class UpdateOrderDto {
+  @IsOptional()
+  @IsNumber()
+  customer_id?: number;
+
+  @IsOptional()
+  @IsDecimal()
+  total_price?: Decimal;
+
+  @IsOptional()
+  @IsString()
+  order_status?: string;
+
+  @IsOptional()
+  @IsString()
+  payment_status?: string;
+
+  @IsOptional()
+  @IsString()
+  pay_slip_image?: string;
+
+  @IsOptional()
+  @IsNumber()
+  enterprise_id?: number;
+}

--- a/src/order/order.controller.spec.ts
+++ b/src/order/order.controller.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { OrderController } from './order.controller';
+import { OrderService } from './order.service';
+import { NotFoundException } from '@nestjs/common';
+import { CreateOrderDto, UpdateOrderDto } from './dto/order.dto';
+import { Decimal } from '@prisma/client/runtime/library';
+
+describe('OrderController', () => {
+  let controller: OrderController;
+  let service: OrderService;
+
+  const mockOrderService = {
+    createOrder: jest.fn(),
+    findAllOrders: jest.fn(),
+    findOrderById: jest.fn(),
+    updateOrder: jest.fn(),
+    deleteOrder: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [OrderController],
+      providers: [
+        {
+          provide: OrderService,
+          useValue: mockOrderService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<OrderController>(OrderController);
+    service = module.get<OrderService>(OrderService);
+  });
+
+  it('should create an order', async () => {
+    const createOrderDto: CreateOrderDto = {
+      customer_id: 1,
+      total_price: new Decimal(100), // Proper handling of Decimal
+      order_status: 'Pending',
+      payment_status: 'Paid',
+      enterprise_id: 1,
+    };
+
+    const mockOrder = {
+      order_id: 1,
+      customer_id: 1,
+      total_price: new Decimal(100), // Ensure mock order uses Decimal as well
+      order_status: 'Pending',
+      payment_status: 'Paid',
+      enterprise_id: 1,
+      order_date: new Date(), // Include any other necessary fields like order_date
+      last_modified_by: 1,
+      pay_slip_image: '',
+    };
+
+    const user: any = { user_id: 1, enterprise_id: 1 };
+
+    // Mock the service's createOrder method to return the mockOrder
+    jest.spyOn(service, 'createOrder').mockResolvedValue(mockOrder);
+
+    // Call the controller's create method
+    const result = await controller.create(createOrderDto, user);
+
+    // Assert that the result matches the mock order
+    expect(result).toEqual(mockOrder);
+
+    // Ensure the service's createOrder method was called with the correct arguments
+    expect(service.createOrder).toHaveBeenCalledWith(createOrderDto, 1, 1);
+  });
+
+  it('should return all orders', async () => {
+    const mockOrders = [
+      {
+        order_id: 1,
+        total_price: new Decimal(100),
+        customer_id: 1,
+        order_status: 'Pending',
+        payment_status: 'Paid',
+        enterprise_id: 1,
+        order_date: new Date(),
+        last_modified_by: 1,
+        pay_slip_image: '',
+      },
+    ];
+
+    jest.spyOn(service, 'findAllOrders').mockResolvedValue(mockOrders);
+
+    const result = await controller.findAll();
+
+    expect(result).toEqual(mockOrders);
+    expect(service.findAllOrders).toHaveBeenCalled();
+  });
+
+  it('should return an order by ID', async () => {
+    const mockOrder = {
+      order_id: 1,
+      total_price: new Decimal(100),
+      customer_id: 1,
+      order_status: 'Pending',
+      payment_status: 'Paid',
+      enterprise_id: 1,
+      order_date: new Date(),
+      last_modified_by: 1,
+      pay_slip_image: '',
+    };
+
+    jest.spyOn(service, 'findOrderById').mockResolvedValue(mockOrder);
+
+    const result = await controller.findOne(1);
+
+    expect(result).toEqual(mockOrder);
+    expect(service.findOrderById).toHaveBeenCalledWith(1);
+  });
+
+  it('should throw NotFoundException if order is not found', async () => {
+    jest.spyOn(service, 'findOrderById').mockResolvedValue(null);
+
+    await expect(controller.findOne(1)).rejects.toThrow(
+      new NotFoundException('Order with ID 1 not found'),
+    );
+  });
+
+  it('should update an order', async () => {
+    const updateOrderDto: UpdateOrderDto = {
+      total_price: new Decimal(150),
+      enterprise_id: 1,
+    };
+
+    const mockUpdatedOrder = {
+      order_id: 1,
+      total_price: new Decimal(150),
+      customer_id: 1,
+      order_status: 'Pending',
+      payment_status: 'Paid',
+      enterprise_id: 1,
+      order_date: new Date(),
+      last_modified_by: 1,
+      pay_slip_image: '',
+    };
+
+    const user: any = { user_id: 1, enterprise_id: 1 };
+
+    jest.spyOn(service, 'updateOrder').mockResolvedValue(mockUpdatedOrder);
+
+    const result = await controller.update(1, updateOrderDto, user);
+
+    expect(result).toEqual(mockUpdatedOrder);
+    expect(service.updateOrder).toHaveBeenCalledWith(1, updateOrderDto, 1, 1);
+  });
+
+  it('should delete an order', async () => {
+    jest.spyOn(service, 'deleteOrder').mockResolvedValue(true);
+
+    const user: any = { user_id: 1, enterprise_id: 1 };
+
+    const result = await controller.delete(1, user);
+
+    expect(result).toBe(true);
+    expect(service.deleteOrder).toHaveBeenCalledWith(1, 1, 1);
+  });
+});

--- a/src/order/order.controller.ts
+++ b/src/order/order.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  Put,
+  Delete,
+  NotFoundException,
+  UseGuards,
+} from '@nestjs/common';
+import { OrderService } from './order.service';
+import { CreateOrderDto, UpdateOrderDto } from './dto/order.dto';
+import { GetUser } from '../auth/decorators/get-user.decorator';
+import { User } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+@Controller('orders')
+@UseGuards(JwtAuthGuard)
+export class OrderController {
+  constructor(private readonly orderService: OrderService) {}
+
+  @Post()
+  async create(@Body() createOrderDto: CreateOrderDto, @GetUser() user: User) {
+    console.log("user: ", user.user_id, user.enterprise_id);
+    
+    return this.orderService.createOrder(createOrderDto, user.user_id, user.enterprise_id); // Example user and enterprise IDs
+  }
+
+  @Get()
+  async findAll() {
+    return this.orderService.findAllOrders();
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: number) {
+    const order = await this.orderService.findOrderById(Number(id));
+    if (!order) {
+      throw new NotFoundException(`Order with ID ${id} not found`);
+    }
+    return order;
+  }
+
+  @Put(':id')
+  async update(
+    @Param('id') id: number,
+    @Body() updateOrderDto: UpdateOrderDto,
+    @GetUser() user: User
+  ) {
+    return this.orderService.updateOrder(Number(id), updateOrderDto, user.user_id, user.enterprise_id);
+  }
+
+  @Delete(':id')
+  async delete(@Param('id') id: number, @GetUser() user: User) {
+    return this.orderService.deleteOrder(Number(id), user.user_id, user.enterprise_id);
+  }
+}

--- a/src/order/order.module.ts
+++ b/src/order/order.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { OrderService } from './order.service';
+import { OrderController } from './order.controller';
+import { PrismaService } from '../prisma/prisma.service'; // Import PrismaService for database interactions
+
+@Module({
+  controllers: [OrderController],
+  providers: [OrderService, PrismaService],
+})
+export class OrderModule {}

--- a/src/order/order.service.spec.ts
+++ b/src/order/order.service.spec.ts
@@ -1,0 +1,235 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../prisma/prisma.service';
+import { OrderService } from './order.service';
+import { CreateOrderDto, UpdateOrderDto } from './dto/order.dto';
+import { Decimal } from '@prisma/client/runtime/library';
+
+describe('OrderService', () => {
+  let service: OrderService;
+  let prisma: PrismaService;
+
+  const mockPrismaService = {
+    order: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    changeLog: {
+      create: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrderService,
+        { provide: PrismaService, useValue: mockPrismaService },
+      ],
+    }).compile();
+
+    service = module.get<OrderService>(OrderService);
+    prisma = module.get<PrismaService>(PrismaService);
+  });
+
+  it('should create a new order', async () => {
+    const createOrderDto: CreateOrderDto = {
+      customer_id: 1,
+      total_price: new Decimal(1000),
+      order_status: 'Pending',
+      payment_status: 'Paid',
+      enterprise_id: 1,
+    };
+
+    const mockOrder = {
+      order_id: 1,
+      ...createOrderDto,
+      order_date: new Date(),
+      pay_slip_image: '',
+      last_modified_by: 1,
+    };
+    const orderData = {
+      ...createOrderDto,
+      order_id: 1,
+      order_date: new Date(),
+      pay_slip_image: '',
+      last_modified_by: 1,
+    };
+    jest.spyOn(prisma.order, 'create').mockResolvedValue(orderData);
+    jest.spyOn(prisma.changeLog, 'create').mockResolvedValue(null);
+
+    const result = await service.createOrder(createOrderDto, 1, 1);
+
+    expect(result).toEqual(mockOrder);
+    expect(prisma.order.create).toHaveBeenCalledWith({
+      data: {
+        ...createOrderDto,
+        enterprise_id: 1,
+        last_modified_by: 1,
+      },
+    });
+    expect(prisma.changeLog.create).toHaveBeenCalledWith({
+      data: {
+        entity_name: 'Order',
+        action: 'create',
+        entity_id: mockOrder.order_id,
+        after_data: mockOrder,
+        user_id: 1,
+        enterprise_id: 1,
+      },
+    });
+  });
+
+  it('should retrieve all orders', async () => {
+    const mockOrders = [
+      {
+        order_id: 1,
+        customer_id: 1,
+        total_price: new Decimal(1000), // Ensure the total_price is a Decimal
+        order_status: 'Pending',
+        payment_status: 'Paid',
+        enterprise_id: 1,
+        order_date: new Date(),
+        pay_slip_image: '',
+        last_modified_by: 1,
+      },
+    ];
+
+    jest.spyOn(prisma.order, 'findMany').mockResolvedValue(mockOrders);
+
+    const result = await service.findAllOrders();
+
+    expect(result).toEqual(mockOrders);
+    expect(prisma.order.findMany).toHaveBeenCalled();
+  });
+
+  it('should find an order by ID', async () => {
+    const mockOrder = {
+      order_id: 1,
+      total_price: new Decimal(100), // Ensure total_price is a Decimal
+      customer_id: 1,
+      order_status: 'Pending',
+      payment_status: 'Paid',
+      enterprise_id: 1,
+      order_date: new Date(),
+      pay_slip_image: '',
+      last_modified_by: 1,
+    };
+
+    jest.spyOn(prisma.order, 'findUnique').mockResolvedValue(mockOrder);
+
+    const result = await service.findOrderById(1);
+
+    expect(result).toEqual(mockOrder);
+    expect(prisma.order.findUnique).toHaveBeenCalledWith({
+      where: { order_id: 1 },
+    });
+  });
+
+  it('should update an order', async () => {
+    const updateOrderDto: UpdateOrderDto = {
+      total_price: new Decimal(150), // Use Decimal for the updated price
+      enterprise_id: 1,
+    };
+
+    const mockBeforeOrder = {
+      order_id: 1,
+      total_price: new Decimal(100), // Ensure total_price is a Decimal
+      customer_id: 1,
+      order_status: 'Pending',
+      payment_status: 'Paid',
+      enterprise_id: 1,
+      order_date: new Date(),
+      pay_slip_image: '',
+      last_modified_by: 1,
+    }; // Before update
+    const mockUpdatedOrder = {
+      order_id: 1,
+      total_price: new Decimal(150), // Ensure total_price is a Decimal
+      customer_id: 1,
+      order_status: 'Pending',
+      payment_status: 'Paid',
+      enterprise_id: 1,
+      order_date: new Date(),
+      pay_slip_image: '',
+      last_modified_by: 1,
+    }; // After update
+
+    // Mock findUnique to return the order before the update
+    jest.spyOn(prisma.order, 'findUnique').mockResolvedValue(mockBeforeOrder);
+    // Mock update to return the updated order
+    jest.spyOn(prisma.order, 'update').mockResolvedValue(mockUpdatedOrder);
+    // Mock changeLog.create to return null (or anything, as it is not the focus here)
+    jest.spyOn(prisma.changeLog, 'create').mockResolvedValue(null);
+
+    const result = await service.updateOrder(1, updateOrderDto, 1, 1);
+
+    // Expect the result to be the updated order
+    expect(result).toEqual(mockUpdatedOrder);
+
+    // Verify that prisma.order.update is called with the correct arguments
+    expect(prisma.order.update).toHaveBeenCalledWith({
+      where: { order_id: 1 },
+      data: {
+        ...updateOrderDto,
+        last_modified_by: 1,
+      },
+    });
+
+    // Verify that the change log is created with the correct data
+    expect(prisma.changeLog.create).toHaveBeenCalledWith({
+      data: {
+        entity_name: 'Order',
+        action: 'update',
+        entity_id: 1,
+        before_data: mockBeforeOrder, // Before data
+        after_data: mockUpdatedOrder, // After data
+        user_id: 1,
+        enterprise_id: 1,
+      },
+    });
+  });
+  it('should delete an order', async () => {
+    const mockBeforeOrder = {
+      order_id: 1,
+      total_price: new Decimal(100), // Ensure total_price is a Decimal
+      customer_id: 1,
+      order_status: 'Pending',
+      payment_status: 'Paid',
+      enterprise_id: 1,
+      order_date: new Date(),
+      pay_slip_image: '',
+      last_modified_by: 1,
+    }; // Before delete
+
+    // Mock findUnique to return the order before the deletion
+    jest.spyOn(prisma.order, 'findUnique').mockResolvedValue(mockBeforeOrder);
+    // Mock delete to simulate the order deletion
+    jest.spyOn(prisma.order, 'delete').mockResolvedValue(mockBeforeOrder); // Could also return the deleted order object
+    // Mock changeLog.create to return null (or anything, as it is not the focus here)
+    jest.spyOn(prisma.changeLog, 'create').mockResolvedValue(null);
+
+    const result = await service.deleteOrder(1, 1, 1);
+
+    // Expect the service to return true after deletion
+    expect(result).toBe(true);
+
+    // Ensure the correct delete call was made
+    expect(prisma.order.delete).toHaveBeenCalledWith({
+      where: { order_id: 1 },
+    });
+
+    // Ensure the change log is created with the correct data
+    expect(prisma.changeLog.create).toHaveBeenCalledWith({
+      data: {
+        entity_name: 'Order',
+        action: 'delete',
+        entity_id: 1,
+        before_data: mockBeforeOrder, // Log the data before deletion
+        user_id: 1,
+        enterprise_id: 1,
+      },
+    });
+  });
+});

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -1,0 +1,130 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateOrderDto, UpdateOrderDto } from './dto/order.dto';
+import { Prisma } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime/library';
+
+@Injectable()
+export class OrderService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // Create a new order
+  async createOrder(
+    createOrderDto: CreateOrderDto,
+    userId: number,
+    enterpriseId: number,
+  ) {
+    try {
+      const order = await this.prisma.order.create({
+        data: {
+          ...createOrderDto,
+          total_price: new Decimal(createOrderDto.total_price),
+          enterprise_id: Number(userId),
+          last_modified_by: Number(enterpriseId),
+        },
+      });
+
+      await this.prisma.changeLog.create({
+        data: {
+          entity_name: 'Order',
+          action: 'create',
+          entity_id: order.order_id,
+          after_data: order,
+          user_id: enterpriseId,
+          enterprise_id: userId,
+        },
+      });
+
+      return order;
+    } catch (error) {
+      throw new Error(`Failed to create order: ${error.message}`);
+    }
+  }
+
+  // Find all orders
+  async findAllOrders() {
+    try {
+      return await this.prisma.order.findMany();
+    } catch (error) {
+      throw new Error(`Failed to retrieve orders: ${error.message}`);
+    }
+  }
+
+  // Find order by ID
+  async findOrderById(orderId: number) {
+    try {
+      return await this.prisma.order.findUnique({
+        where: { order_id: orderId },
+      });
+    } catch (error) {
+      throw new Error(`Failed to retrieve order: ${error.message}`);
+    }
+  }
+
+  // Update order
+  async updateOrder(
+    orderId: number,
+    updateOrderDto: UpdateOrderDto,
+    userId: number,
+    enterpriseId: number,
+  ) {
+    try {
+      const beforeData = await this.prisma.order.findUnique({
+        where: { order_id: orderId },
+      });
+
+      const updatedOrder = await this.prisma.order.update({
+        where: { order_id: orderId },
+        data: {
+          ...updateOrderDto,
+          total_price: new Decimal(updateOrderDto.total_price),
+          last_modified_by: userId,
+        },
+      });
+
+      await this.prisma.changeLog.create({
+        data: {
+          entity_name: 'Order',
+          action: 'update',
+          entity_id: orderId,
+          before_data: beforeData,
+          after_data: updatedOrder,
+          user_id: userId,
+          enterprise_id: enterpriseId,
+        },
+      });
+
+      return updatedOrder;
+    } catch (error) {
+      throw new Error(`Failed to update order: ${error.message}`);
+    }
+  }
+
+  // Delete order
+  async deleteOrder(orderId: number, userId: number, enterpriseId: number) {
+    try {
+      const beforeData = await this.prisma.order.findUnique({
+        where: { order_id: orderId },
+      });
+
+      await this.prisma.order.delete({
+        where: { order_id: orderId },
+      });
+
+      await this.prisma.changeLog.create({
+        data: {
+          entity_name: 'Order',
+          action: 'delete',
+          entity_id: orderId,
+          before_data: beforeData,
+          user_id: userId,
+          enterprise_id: enterpriseId,
+        },
+      });
+
+      return true;
+    } catch (error) {
+      throw new Error(`Failed to delete order: ${error.message}`);
+    }
+  }
+}


### PR DESCRIPTION
- Added optional enterprise_id field to the User model for optional association with the Enterprise model.
- Created a relationship between User and Enterprise models where each user can optionally belong to one enterprise.
- Updated Prisma schema to reflect the new foreign key relation (enterprise_id).
- Ensured backward compatibility with existing users who may not be associated with an enterprise.
